### PR TITLE
Solve leapyear problem

### DIFF
--- a/Task-4/leapyear.cpp
+++ b/Task-4/leapyear.cpp
@@ -3,16 +3,28 @@ using namespace std;
  
 bool checkLeapYear(int year)
 {
-    return false;
+    return year % 4 == 0 && year % 400 != 0;
+}
+
+void outputLeapYear(int year) {
+    cout << year << " was ";
+    checkLeapYear(year) ? cout << "a Leap Year": cout << "Not a Leap Year";
+    cout << "\n";
 }
 
 int main()
 {
-    checkLeapYear(2000) ? cout << "Leap Year": cout << "Not a Leap Year";
+    outputLeapYear(1900);
+    // 2000 was not a Leap Year
+    
+    outputLeapYear(2000);
+    // 2000 was a Leap Year
+    
+    outputLeapYear(2004);
     // 2000 was a Leap Year
                     
-    checkLeapYear(2022) ? cout << "Leap Year": cout << "Not a Leap Year";
-    // 2020 was not a Leap Year
+    outputLeapYear(2022);
+    // 2022 was not a Leap Year
     
     return 0;
 }

--- a/Task-4/leapyear.cpp
+++ b/Task-4/leapyear.cpp
@@ -3,7 +3,7 @@ using namespace std;
  
 bool checkLeapYear(int year)
 {
-    return year % 4 == 0 && year % 400 != 0;
+    return year % 400 == 0 || year % 4 == 0 && year % 100 != 0;
 }
 
 void outputLeapYear(int year) {
@@ -15,13 +15,13 @@ void outputLeapYear(int year) {
 int main()
 {
     outputLeapYear(1900);
-    // 2000 was not a Leap Year
+    // 1900 was not a Leap Year
     
     outputLeapYear(2000);
     // 2000 was a Leap Year
     
     outputLeapYear(2004);
-    // 2000 was a Leap Year
+    // 2004 was a Leap Year
                     
     outputLeapYear(2022);
     // 2022 was not a Leap Year


### PR DESCRIPTION
Solved the leap year problem: leap years are those years that are divisible by 4, except those years that are divisible by 100, in which case those years that are divisible by 100 are only leap years if they are also divisible by 400.

Thus 1900 is not a leap year despite being divisible by 4 because it is not divisible by 400.

However, 2000 is a leap year because it is divisible by 400.